### PR TITLE
Feat  connect yapo scraper to backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# fb_mkt
+C_USER= 
+XS= 
+N_SCROLLS=15 # de esta linea para abajo se pueden dejar estos valores para probar
+T_SCROLL=6
+MIN_PRICE=100000
+
+# post to scrapers (localhost si es local)
+VERCEL_BACKEND_URL=

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ FB_T_SCROLL=6
 FB_MIN_PRICE=100000
 
 # yapo
-YP_N_PAGES=0 # esto puede dejarse asi
+YP_N_PAGES=1 # esto puede dejarse asi
 
 # ruta para post de los srapers "(localhost en local)
 VERCEL_BACKEND_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,12 @@
 # fb_mkt
-C_USER= 
-XS= 
-N_SCROLLS=15 # de esta linea para abajo se pueden dejar estos valores para probar
-T_SCROLL=6
-MIN_PRICE=100000
+FB_C_USER= # sesión
+FB_XS= # sesión
+FB_N_SCROLLS=2 # esto puede dejarse asi
+FB_T_SCROLL=6
+FB_MIN_PRICE=100000
 
-# post to scrapers (localhost si es local)
+# yapo
+YP_N_PAGES=0 # esto puede dejarse asi
+
+# ruta para post de los srapers "(localhost en local)
 VERCEL_BACKEND_URL=

--- a/.github/workflows/fbscraper.yml
+++ b/.github/workflows/fbscraper.yml
@@ -1,0 +1,27 @@
+name: Run fb_mkt scraper
+# este run es un placeholder, falta arreglar el scraper de fb
+# las variables de entorno cargan bien
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: Run fb crawler
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      C_USER: ${{ secrets.C_USER }}
+      XS: ${{ secrets.XS }}
+      N_SCROLLS: ${{ vars.N_SCROLLS }}
+      T_SCROLL: ${{ vars.T_SCROLL }}
+      MIN_PRICE: ${{ vars.MIN_PRICE }}
+      
+      VERCEL_BACKEND_URL: ${{ secrets.VERCEL_BACKEND_URL }}
+      
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-env
+      - name: Execute script
+        run:  echo ""
+        # run: poetry run python3 ./src/scrapers/fb_scraper/main.py

--- a/.github/workflows/fbscraper.yml
+++ b/.github/workflows/fbscraper.yml
@@ -11,11 +11,11 @@ jobs:
     environment: production
 
     env:
-      C_USER: ${{ secrets.C_USER }}
-      XS: ${{ secrets.XS }}
-      N_SCROLLS: ${{ vars.N_SCROLLS }}
-      T_SCROLL: ${{ vars.T_SCROLL }}
-      MIN_PRICE: ${{ vars.MIN_PRICE }}
+      C_USER: ${{ secrets.FB_C_USER }}
+      XS: ${{ secrets.FB_XS }}
+      N_SCROLLS: ${{ vars.FB_N_SCROLLS }}
+      T_SCROLL: ${{ vars.FB_T_SCROLL }}
+      MIN_PRICE: ${{ vars.FB_MIN_PRICE }}
       
       VERCEL_BACKEND_URL: ${{ secrets.VERCEL_BACKEND_URL }}
       
@@ -23,5 +23,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-env
       - name: Execute script
-        run:  echo ""
-        # run: poetry run python3 ./src/scrapers/fb_scraper/main.py
+        run: poetry run python3 ./src/scrapers/fb_scraper/main.py

--- a/.github/workflows/yaposcraper.yml
+++ b/.github/workflows/yaposcraper.yml
@@ -2,6 +2,8 @@ name: Run yapo scraper
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   run:
@@ -10,7 +12,7 @@ jobs:
     environment: production
 
     env:
-      
+      YP_N_PAGES: ${{ vars.YP_N_PAGES }}
       VERCEL_BACKEND_URL: ${{ secrets.VERCEL_BACKEND_URL }}
 
     steps:

--- a/.github/workflows/yaposcraper.yml
+++ b/.github/workflows/yaposcraper.yml
@@ -7,6 +7,12 @@ jobs:
   run:
     name: Run yapo scraper
     runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      
+      VERCEL_BACKEND_URL: ${{ secrets.VERCEL_BACKEND_URL }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "python-dotenv>=1.1.0,<2.0.0",
     "coverage>=7.8.0,<8.0.0",
     "pre-commit>=4.2.0,<5.0.0",
-    "ruff>=0.11.8,<0.12.0"
+    "ruff>=0.11.8,<0.12.0",
+    "requests (>=2.32.3,<3.0.0)"
 ]
 
 [tool.poetry]

--- a/src/scrapers/fb_scraper/fbcrawler.py
+++ b/src/scrapers/fb_scraper/fbcrawler.py
@@ -3,12 +3,17 @@ from playwright.sync_api import sync_playwright
 from dotenv import dotenv_values
 from bs4 import BeautifulSoup
 import os
-import sys
 import time
 import json
 import re
 
-config = {**dotenv_values(".env"), **os.environ}
+# Cargar el .env si existe
+env_config = {}
+if os.path.exists(".env"):
+    env_config = dotenv_values(".env")
+
+# Mezclar variables, dando prioridad a las del entorno
+config = {**env_config, **os.environ}
 
 
 def crawl_facebook_marketplace():
@@ -154,7 +159,7 @@ def save_to_json(data, output_file):
     print("Cantidad total de vehiculos (sin repetidos): ", len(parsed))
 
 
-if __name__ == "__main__":
+def main():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     start = time.time()
     elements = crawl_facebook_marketplace(os.path.join(current_dir, "fb_sessions.txt"))
@@ -162,5 +167,10 @@ if __name__ == "__main__":
         f.write(json.dumps(elements))
     end = time.time()
     print("Tiempo total de scrapeo: ", end - start)
-    # save_to_json(elements, "cars.json") # TO DO: implementar una forma de conectar a la db
-    sys.exit(0)
+    save_to_json(
+        elements, "cars.json"
+    )  # TO DO: implementar una forma de conectar a la db
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scrapers/fb_scraper/fbcrawler.py
+++ b/src/scrapers/fb_scraper/fbcrawler.py
@@ -22,14 +22,14 @@ def crawl_facebook_marketplace():
     # https://www.facebook.com/marketplace/santiagocl/carros
 
     initial_url = "https://www.facebook.com/marketplace/"
-    min_price = (
-        int(config["MIN_PRICE"]) or 100000
+    min_price = int(
+        config["FB_MIN_PRICE"]
     )  # mejor usar un precio minimo para descartar publicaciones raras
-    n_scrolls = int(config["N_SCROLLS"]) or 15
-    wait_between_scrolls = int(config["T_SCROLL"]) or 6
+    n_scrolls = int(config["FB_N_SCROLLS"])
+    wait_between_scrolls = int(config["FB_T_SCROLL"])
 
-    c_user = config["C_USER"]
-    xs = config["XS"]
+    c_user = config["FB_C_USER"]
+    xs = config["FB_XS"]
     cookie1 = {
         "name": "c_user",
         "value": c_user,

--- a/src/scrapers/yapo/main.py
+++ b/src/scrapers/yapo/main.py
@@ -150,7 +150,7 @@ def get_details(base_url: str, links_list: list[tuple[str]], retries: int = 3):
                         attr_dict[e[0]] = " ".join(e[1 : len(e)])
                 dict_list.append(attr_dict)
                 time.sleep(1)
-            except Exception as e:
+            except Exception:
                 continue
         browser.close()
         return dict_list
@@ -187,7 +187,6 @@ def save_to_json(
             )
             parsed_cars.append(car.model_dump())
         except KeyError:  # llave no encontrada
-            # print(e)
             continue
         except Exception:
             continue
@@ -227,7 +226,6 @@ def post_cars(
             )
             parsed_cars.append(car.model_dump())
         except KeyError:  # llave no encontrada
-            # print(e)
             continue
         except Exception:
             continue

--- a/src/scrapers/yapo/main.py
+++ b/src/scrapers/yapo/main.py
@@ -26,7 +26,7 @@ def scrape_yapo(base_url: str, pages: int, retries: int = 3):
     car_listing_links = []
     with sync_playwright() as p:
         browser = p.chromium.launch(
-            headless=False
+            headless=True
             # , proxy= {}
         )
         context = browser.new_context(


### PR DESCRIPTION
## 🖼️ Contexto
Se finalizó la implementación del scraper de yapo junto con la conexión a la url del backend, también se configuraron variables de entorno y secrets para facilitar la configuración de los scrapers de yapo y facebook marketplace. Por último se terminó el workflow del scraper de yapo añadiendo un cron y variables de entorno.
## 🛠️ Cambios realizados
- Se completo la implementación del scraper de yapo, es capaz de buscar los datos y mandar las requests hacia la url del .env o del entorno configurado en git. El nombre es `VERCEL_BACKEND_URL`
- Se añadió un ejemplo de env para que funcione el scraper de yapo y de facebook (el de facebook no funciona ahora mismo porque cambió la página de marketplace).
- Se agregó un workflow de yapo para ejecutar el scraper junto con un cron que se ejecuta a la misma hora que el scraper de kavak
## 🧐 ¿Cómo se ve o cómo se prueba?
- Para correr el script ejecutar: 
```
poetry run yapo-scrap
```
- Para probar el script en local: es necesario setear `VERCEL_BACKEND_URL` a un endpoint local (como localhost) y `YP_N_PAGES `a un valor mayor a 0, la cantidad de autos que contiene una página es 30, y considerar que cada auto de demora como 5 segundos, entonces si `YP_N_PAGES ` es muy grande se puede demorar mucho tiempo. Un valor de 4 extraería alrededor de 120 autos **(10 minutos).**
- Para probar en la app: lo mismo pero setear `VERCEL_BACKEND_URL` al endpoint abierto de la aplicación. 
- Para probar en el workflow: ejecutar el workflow manualmente desde actions, seteando antes las variable de entorno `VERCEL_BACKEND_URL` y `YP_N_PAGES` al valor deseado (desde la cuenta de carplace ir a `settings -> environments-> production` )