### PR TITLE
Refactor  yapo scraper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@ FB_T_SCROLL=6
 FB_MIN_PRICE=100000
 
 # yapo
-YP_N_PAGES=1 # esto puede dejarse asi
+YP_N_PAGES=1
+YP_BASE_URL="https://public-api.yapo.cl/autos-usados/region-metropolitana"
+YP_DEFAULT_URL="https://public-api.yapo.cl"
 
 # ruta para post de los srapers "(localhost en local)
 VERCEL_BACKEND_URL=

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ FB_MIN_PRICE=100000
 
 # yapo
 YP_N_PAGES=1
-YP_BASE_URL="https://public-api.yapo.cl/autos-usados/region-metropolitana"
-YP_DEFAULT_URL="https://public-api.yapo.cl"
+YP_BASE_URL=https://public-api.yapo.cl/autos-usados/region-metropolitana
+YP_DEFAULT_URL=https://public-api.yapo.cl
 
 # ruta para post de los srapers "(localhost en local)
 VERCEL_BACKEND_URL=

--- a/.github/workflows/yaposcraper.yml
+++ b/.github/workflows/yaposcraper.yml
@@ -13,6 +13,8 @@ jobs:
 
     env:
       YP_N_PAGES: ${{ vars.YP_N_PAGES }}
+      YP_BASE_URL: ${{ vars.YP_BASE_URL }}
+      YP_DEFAULT_URL: ${{ vars.YP_DEFAULT_URL }}
       VERCEL_BACKEND_URL: ${{ secrets.VERCEL_BACKEND_URL }}
 
     steps:

--- a/src/scrapers/utils.py
+++ b/src/scrapers/utils.py
@@ -1,0 +1,39 @@
+# Enums para normalización
+class FuelTypeEnum:
+    GAS = "gas"
+    DIESEL = "diesel"
+    ELECTRICITY = "electricity"
+    HYBRID = "hybrid"
+    OTHER = "other"
+
+
+class TransmissionTypeEnum:
+    AUTOMATIC = "automatic"
+    MANUAL = "manual"
+    OTHER = "other"
+
+
+def normalize_fuel_type(raw_fuel: str | None) -> str | None:
+    if not raw_fuel:
+        return None
+    raw = raw_fuel.lower()
+    if "bencina" in raw or "gasolina" in raw or "gas" in raw:
+        return FuelTypeEnum.GAS
+    if "diesel" in raw:
+        return FuelTypeEnum.DIESEL
+    if "eléctrico" in raw or "electric" in raw:
+        return FuelTypeEnum.ELECTRICITY
+    if "híbrido" in raw or "hybrid" in raw:
+        return FuelTypeEnum.HYBRID
+    return FuelTypeEnum.OTHER
+
+
+def normalize_transmission(raw_trans: str | None) -> str:
+    if not raw_trans:
+        return TransmissionTypeEnum.OTHER
+    raw = raw_trans.lower()
+    if "automático" in raw or "automatic" in raw or "automática" in raw:
+        return TransmissionTypeEnum.AUTOMATIC
+    if "manual" in raw:
+        return TransmissionTypeEnum.MANUAL
+    return TransmissionTypeEnum.OTHER


### PR DESCRIPTION
## 🖼️ Contexto
Se reescribió el código de yapo para seguir el mismo formato del nuevo schema de la base de datos y se mejoro la calidad del codigo.
## 🛠️ Cambios realizados
- Se reescribieron algunas funciones del scraper de yapo para disminuir la redundancia y se eliminaron las funciones innecesarias
- Se creó un archio utils.py con las funciones de kavak (que fueron usadas también en el scraper de yapo) para estandarizar el tipo de combustible y transmisión
- Se cambiaron las variables del workflow de yapo y ahora las urls son variables de entorno
- Ahora el scraper inyecta directamente los autos a medida que va descubriendo nuevas publicaciones
## 🧐 ¿Cómo se ve o cómo se prueba?
- En local ejecutar`poetry run yapo-scrap`
- Ejecutar el workflow desde actions en la rama "refactor--yapo-scraper"